### PR TITLE
Update to support running with pydantic v2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - openapi-spec-validator >=0.2.8,<=0.5.1
     - packaging
     - prance >=0.18.2,<1.0
-    - pydantic >=1.5.1,<2.0
+    - pydantic >=1.5.1,<3.0
     - python >=3.7,<4.0
     - pysnooper >=0.4.1,<2.0.0
     - toml >=0.10.0,<1.0.0


### PR DESCRIPTION
Allow for v2 versions of pydantic as upstream has supported it since 0.21.0